### PR TITLE
Rebuild netcdf4 1.5.7 against libnetcdf 4.8.1 on all arches

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - c3i_test2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - c3i_test2

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 if [[ $(uname) == Darwin ]]; then
-    export LDFLAGS="-headerpad_max_install_names $LDFLAGS"
+    export LDFLAGS="-headerpad_max_install_names ${LDFLAGS}"
 fi
 
-export netCDF4_DIR=$PREFIX
-export HDF5_DIR=$PREFIX
+export NETCDF4_DIR="${PREFIX}"
+export HDF5_DIR="${PREFIX}"
 
-${PYTHON} -m pip install --no-deps --ignore-installed .
+${PYTHON} -m pip install \
+    --use-feature=in-tree-build \
+    --no-binary :all: \
+    --no-deps \
+    --ignore-installed .

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,2 @@
 libnetcdf:
-  - 4.8  # [not (osx and arm64)]
-  - 4.8  # [osx and arm64]
+  - 4.8

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+libnetcdf:
+  - 4.8  # [not (osx and arm64)]
+  - 4.8  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: 5673896d1d39d591423abbd4856270cc901b88bdbeaf4ab293bfd7cfd77fe8d5
 
 build:
-  number: 0
-  # trigger: 1
+  number: 1
   skip: True  # [s390x]
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
@@ -29,7 +28,7 @@ requirements:
     - cython >=0.19
     - cftime
     - hdf5
-    - libnetcdf
+    - libnetcdf >=4.8.1
     - setuptools >=18.0
     - wheel
   run:
@@ -38,7 +37,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - cftime
     - hdf5
-    - libnetcdf
+    - {{ pin_compatible('libnetcdf', min_pin='x.x', max_pin='x.x') }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,13 @@ source:
 build:
   number: 0
   # trigger: 1
+  skip: True  # [s390x]
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3
     - nc3tonc4 = netCDF4.utils:nc3tonc4
+  ignore_run_exports:
+    - hdf5
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,8 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - cftime
     - hdf5
-    - libnetcdf <4.8.0
+    - libnetcdf <4.8.0  # [not (osx and arm64)]
+    - libnetcdf  # [osx and arm64]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/netCDF4/netCDF4-{{version}}.tar.gz
-  sha256: d145f9c12da29da3922d8b8aafea2a2a89501bcb28a219a46b7b828b57191594
+  url: https://github.com/Unidata/netcdf4-python/archive/v{{version}}rel.tar.gz
+  sha256: 5673896d1d39d591423abbd4856270cc901b88bdbeaf4ab293bfd7cfd77fe8d5
 
 build:
   number: 0
@@ -35,7 +35,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - cftime
     - hdf5
-    - libnetcdf
+    - libnetcdf <4.8.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - cftime
     - hdf5
-    - libnetcdf <4.8.0  # [not (osx and arm64)]
-    - libnetcdf  # [osx and arm64]
+    - libnetcdf
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  # trigger: 1
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -11,8 +11,7 @@ os.environ['TEMP'] = os.environ['PREFIX']
 #    # Compiled with cython.
 #    assert nc.filepath() == url
 
-
-url = 'http://geoport.whoi.edu/thredds/dodsC/usgs/vault0/models/tides/vdatum_gulf_of_maine/adcirc54_38_orig.nc'
-
-with netCDF4.Dataset(url) as nc:
-    nc['tidenames'][:]
+## (tkoch, 2022-01-10) disabled, server is unreachable
+#url = 'http://geoport.whoi.edu/thredds/dodsC/usgs/vault0/models/tides/vdatum_gulf_of_maine/adcirc54_38_orig.nc'
+#with netCDF4.Dataset(url) as nc:
+#    nc['tidenames'][:]


### PR DESCRIPTION
Even though we have had more recent versions of libnetcdf available, netcdf4 has so far been linked against libnetcdf 4.6 (except for osx-arm64). This rebuilds netcdf4 against libnetcdf 4.8.1 on all architectures.

Current situation:

```
--------------------------------------------------------------------
# linux-64
--------------------------------------------------------------------
* netcdf4                        1.5.7  py36h0a24e14_0  pkgs/main
* netcdf4                        1.5.7  py37h0a24e14_0  pkgs/main
* netcdf4                        1.5.7  py38h0a24e14_0  pkgs/main
* netcdf4                        1.5.7  py39h0a24e14_0  pkgs/main
* netcdf4                        1.5.7  py39he70f4c8_0  pkgs/main

--------------------------------------------------------------------
# linux-ppc64le
--------------------------------------------------------------------
* netcdf4                        1.5.7  py36h4785779_0  pkgs/main
* netcdf4                        1.5.7  py37h4785779_0  pkgs/main
* netcdf4                        1.5.7  py38h4785779_0  pkgs/main
* netcdf4                        1.5.7  py39h353ab3d_0  pkgs/main
* netcdf4                        1.5.7  py39h4785779_0  pkgs/main

--------------------------------------------------------------------
# linux-aarch64
--------------------------------------------------------------------
* netcdf4                        1.5.6  py37hdd8981e_0  pkgs/main
* netcdf4                        1.5.6  py38hdd8981e_0  pkgs/main
* netcdf4                        1.5.6  py39hdd8981e_0  pkgs/main

--------------------------------------------------------------------
# linux-s390x
--------------------------------------------------------------------
->Package "netcdf4=1.5" not found!

--------------------------------------------------------------------
# osx-64
--------------------------------------------------------------------
* netcdf4                        1.5.7  py36h1695cb1_0  pkgs/main
* netcdf4                        1.5.7  py37h1695cb1_0  pkgs/main
* netcdf4                        1.5.7  py38h1695cb1_0  pkgs/main
* netcdf4                        1.5.7  py39h1695cb1_0  pkgs/main
* netcdf4                        1.5.7  py39h93ad9c5_0  pkgs/main

--------------------------------------------------------------------
# osx-arm64
--------------------------------------------------------------------
* netcdf4                        1.5.7  py38h42109b7_0  pkgs/main
* netcdf4                        1.5.7  py39h42109b7_0  pkgs/main

--------------------------------------------------------------------
# win-32
--------------------------------------------------------------------
* netcdf4                        1.5.7  py36h618db37_0  pkgs/main
* netcdf4                        1.5.7  py37h618db37_0  pkgs/main
* netcdf4                        1.5.7  py38h618db37_0  pkgs/main
* netcdf4                        1.5.7  py39h618db37_0  pkgs/main
* netcdf4                        1.5.7  py39h7cf66cd_0  pkgs/main

--------------------------------------------------------------------
# win-64
--------------------------------------------------------------------
* netcdf4                        1.5.7  py36hb33177a_0  pkgs/main
* netcdf4                        1.5.7  py37hb33177a_0  pkgs/main
* netcdf4                        1.5.7  py38hb33177a_0  pkgs/main
* netcdf4                        1.5.7  py39hb33177a_0  pkgs/main
* netcdf4                        1.5.7  py39hb76ebac_0  pkgs/main
```