### PR TITLE
netcdf4 1.7.4 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "netcdf4" %}
-{% set version = "1.7.2" %}
+{% set version = "1.7.4" %}
 
 package:
   name: {{ name }}
@@ -7,19 +7,20 @@ package:
 
 source:
   url: https://github.com/Unidata/{{ name }}-python/archive/v{{version}}rel.tar.gz
-  sha256: cce7d42a83f84b6ce6288bb2fb171d5ffd294f1a1ba2650807d238ae961e9629
+  sha256: c792977eb762fd29fa46b78f44dd8c15729fe7733c2cd2ecd34552089734ce4b
   patches:  # [win]
     - patches/00_fix_win_test.patch  # [win]
 
 build:
-  number: 2
-  skip: True  # [py<38]
+  number: 0
+  skip: True  # [py<310]
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3
     - nc3tonc4 = netCDF4.utils:nc3tonc4
   ignore_run_exports:
     - hdf5
+    - numpy
 
 requirements:
   build:
@@ -28,32 +29,31 @@ requirements:
   host:
     - python
     - pip
-    - numpy {{ numpy }}
     - cython >=0.29
-    - hdf5  {{ hdf5 }}
-    - libnetcdf {{ libnetcdf }}
-    - setuptools >=61
+    - numpy {{ numpy }}
+    - setuptools >=77.0.1
     - setuptools-scm >=3.4
-    - toml
-    - wheel
+    - hdf5 {{ hdf5 }}
+    - libnetcdf {{ libnetcdf }}
   run:
     - python
-    - numpy
     - cftime
     - certifi
+    - numpy
     - hdf5
-    - {{ pin_compatible('libnetcdf', min_pin='x.x', max_pin='x.x') }}
+    - libnetcdf
 
 test:
   source_files:
     - test
-  imports:
+  imports: 
     - netCDF4
     - cftime
   requires:
-    - cython
     - pip
+    - cython
     - packaging
+    - pytest
   commands:
     - pip check
     - ncinfo -h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,11 @@ requirements:
     - python
     - cftime
     - certifi
+    # Version through run exports
     - numpy
+    # Version through run exports
     - hdf5
+    # Version through run exports
     - libnetcdf
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - numpy {{ numpy }}
     - setuptools >=77.0.1
     - setuptools-scm >=3.4
+    - toml
     - hdf5 {{ hdf5 }}
     - libnetcdf {{ libnetcdf }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,6 @@ build:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3
     - nc3tonc4 = netCDF4.utils:nc3tonc4
-  ignore_run_exports:
-    - hdf5
-    - numpy
 
 requirements:
   build:


### PR DESCRIPTION
netcdf4 1.7.4 

**Destination channel:** Defaults

### Links

- [PKG-11764]
- dev_url:        https://github.com/Unidata/netcdf4-python/tree/v1.7.4rel
- conda_forge:    https://github.com/conda-forge/netcdf4-feedstock
- pypi:           https://pypi.org/project/netcdf4/1.7.4
- pypi inspector: https://inspector.pypi.io/project/netcdf4/1.7.4

### Explanation of changes:

- new version number


[PKG-11764]: https://anaconda.atlassian.net/browse/PKG-11764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ